### PR TITLE
expand testing

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,11 +23,61 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Write a Conda Env File
+        run: |
+          cat > export.yaml <<EOF
+          name: einsums-dev
+          channels:
+            - conda-forge
+            - nodefaults
+          dependencies:
+            - cmake
+            - ninja
+            - cxx-compiler
+            - catch2
+            - fftw
+            - fmt
+            - range-v3
+            - blas-devel
+            #MKL- libblas=*=*mkl
+            #OB- libblas=*=*openblas
+            #OB- openblas=*=*openmp*
+            #OB- liblapacke
+            - hdf5
+            - zlib
+            - elfutils
+          EOF
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            # :
+            # sed -i "s;;;g" export.yaml
+            if [[ "${{ matrix.build_type }}" == "Release" ]]; then
+              sed -i "s;#MKL;;g" export.yaml
+            else
+              sed -i "s;#OB;;g" export.yaml
+            fi
+          fi
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            # :
+            # sed -E -i.bak "s;;;g" export.yaml
+            if [[ "${{ matrix.build_type }}" == "Release" ]]; then
+              sed -E -i.bak "s;#MKL;;g" export.yaml
+            else
+              sed -E -i.bak "s;#OB;;g" export.yaml
+            fi
+            sed -E -i.bak "s;- elfutils;;g" export.yaml
+          fi
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            :
+            # sed -i "s;;;g" export.yaml
+          fi
+          cat export.yaml
+
       - name: Install dependencies
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: einsums-dev
-          environment-file: devtools/conda-envs/${{matrix.environment}}
+          #environment-file: devtools/conda-envs/${{matrix.environment}}
+          environment-file: export.yaml
           miniforge-variant: Mambaforge
           use-mamba: true
           channels: conda-forge
@@ -36,7 +86,7 @@ jobs:
       - name: Confound Environment - test fetched cblas/lapacke
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.build_type == 'Debug' && matrix.hptt == 'HPTT=OFF' }}
         run: |
-          conda remove liblapacke libcblas
+          conda remove liblapacke libcblas --solver=libmamba
 
       - name: Configure CMake
         run: cmake -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DEINSUMS_SHOW_WARNING=OFF -DEINSUMS_USE_${{matrix.hptt}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -101,5 +101,5 @@ jobs:
         run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
 
       - name: Test
-        working-directory: ${{github.workspace}}/build/tests
-        run: ./test-all
+        working-directory: ${{github.workspace}}/build
+        run: ctest

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,9 +40,10 @@ jobs:
             - range-v3
             - blas-devel
             #MKL- libblas=*=*mkl
-            #OB- libblas=*=*openblas
-            #OB- openblas=*=*openmp*
-            #OB- liblapacke
+            #ACC- libblas=*=*accelerate
+            #OBL- libblas=*=*openblas
+            #OBL- openblas=*=*openmp*
+            #OBL- liblapacke
             - hdf5
             - zlib
             - elfutils
@@ -53,16 +54,16 @@ jobs:
             if [[ "${{ matrix.build_type }}" == "Release" ]]; then
               sed -i "s;#MKL;;g" export.yaml
             else
-              sed -i "s;#OB;;g" export.yaml
+              sed -i "s;#OBL;;g" export.yaml
             fi
           fi
           if [[ "${{ runner.os }}" == "macOS" ]]; then
             # :
             # sed -E -i.bak "s;;;g" export.yaml
             if [[ "${{ matrix.build_type }}" == "Release" ]]; then
-              sed -E -i.bak "s;#MKL;;g" export.yaml
+              sed -E -i.bak "s;#ACC;;g" export.yaml
             else
-              sed -E -i.bak "s;#OB;;g" export.yaml
+              sed -E -i.bak "s;#OBL;;g" export.yaml
             fi
             sed -E -i.bak "s;- elfutils;;g" export.yaml
           fi

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -88,6 +88,11 @@ jobs:
         run: |
           conda remove liblapacke libcblas --solver=libmamba
 
+      - name: Conda environment
+        run: |
+          mamba info
+          mamba list
+
       - name: Configure CMake
         run: cmake -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DEINSUMS_SHOW_WARNING=OFF -DEINSUMS_USE_${{matrix.hptt}}
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -43,7 +43,7 @@ jobs:
             #ACC- libblas=*=*accelerate
             #OBL- libblas=*=*openblas
             #OBL- openblas=*=*openmp*
-            #OBL- liblapacke
+            - liblapacke
             - hdf5
             - zlib
             - elfutils

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,8 +49,6 @@ jobs:
             - elfutils
           EOF
           if [[ "${{ runner.os }}" == "Linux" ]]; then
-            # :
-            # sed -i "s;;;g" export.yaml
             if [[ "${{ matrix.build_type }}" == "Release" ]]; then
               sed -i "s;#MKL;;g" export.yaml
             else
@@ -58,19 +56,18 @@ jobs:
             fi
           fi
           if [[ "${{ runner.os }}" == "macOS" ]]; then
-            # :
-            # sed -E -i.bak "s;;;g" export.yaml
-            if [[ "${{ matrix.build_type }}" == "Release" ]]; then
-              sed -E -i.bak "s;#ACC;;g" export.yaml
-            else
-              sed -E -i.bak "s;#OBL;;g" export.yaml
-            fi
+            sed -E -i.bak "s;#OBL;;g" export.yaml
             sed -E -i.bak "s;- elfutils;;g" export.yaml
           fi
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             :
-            # sed -i "s;;;g" export.yaml
           fi
+          # for empty bash block
+          #   :
+          # model sed for L/W
+          #   sed -i "s;;;g" export.yaml
+          # model sed for M
+          #   sed -E -i.bak "s;;;g" export.yaml
           cat export.yaml
 
       - name: Install dependencies
@@ -100,6 +97,11 @@ jobs:
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
 
-      - name: Test
+      - name: Test (CTest)
         working-directory: ${{github.workspace}}/build
         run: ctest
+
+      - name: Test (Catch2)
+        if: false
+        working-directory: ${{github.workspace}}/build/tests
+        run: ./test-all

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,12 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(EinsumsBranding)
 
 project(
-  einsums
+  Einsums
   VERSION ${EINSUMS_VERSION}
-  LANGUAGES C CXX)
+  LANGUAGES C CXX
+  DESCRIPTION "C++ library for compile-time contraction pattern analysis optimizing tensor operations"
+  HOMEPAGE_URL https://github.com/jturney/einsums
+  )
 
 include(FeatureSummary)
 include(EinsumsAPI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,9 +109,11 @@ include(cmake/BackwardConfig.cmake)
 add_subdirectory(external)
 add_subdirectory(src)
 
-enable_testing()
+if (EINSUMS_ENABLE_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
 
-add_subdirectory(tests)
 add_subdirectory(timing)
 # add_subdirectory(experiments)
 

--- a/cmake/EinsumsConfig.cmake.in
+++ b/cmake/EinsumsConfig.cmake.in
@@ -1,0 +1,167 @@
+# EinsumsConfig.cmake
+# -------------------
+#
+# Einsums cmake module.
+# This module sets the following variables in your project::
+#
+##   ambit_FOUND - true if ambit and all required components found on the system
+##   ambit_VERSION - ambit version in format Major.Minor.Release. Prefer target variable.
+##   ambit_INCLUDE_DIRS - Directory where ambit/tensor.h header is located and dependent headers. Prefer targets.
+##   ambit_INCLUDE_DIR - same as DIRS. Prefer targets.
+##   ambit_DEFINITIONS - Definitions necessary to use ambit, namely USING_ambit. Prefer targets.
+##   ambit_LIBRARIES - ambit library to link against plus any dependent libraries. Prefer targets.
+##   ambit_LIBRARY - ambit library to link against. Prefer targets
+##   ambit_PYMOD - path to pyambit python module (suitable for appending PYTHONPATH). Only present
+##                 with Python component. Prefer pyambit target variable.
+##
+##
+## Target variables::
+##
+## It is preferred to use properties set on the base target rather than using the above variables. ::
+##
+##   ambit_VERSION - ambit version in format Major.Minor.Release
+##   ambit_PYMOD - path to ambit python module (suitable for appending PYTHONPATH). Only on pyambit target.
+##
+##   get_property(_ver TARGET ambit::ambit PROPERTY ambit_VERSION)
+##
+##
+## Available components: shared static Python ::
+##
+##   shared - search for only shared library
+##   static - search for only static library
+##   Python - search for Python bindings library
+##
+##
+## Exported targets::
+##
+## If ambit is found, this module defines at least the first following
+## :prop_tgt:`IMPORTED` target. Depending on components available, it may define::
+##
+##   ambit::ambit - the main ambit library with header & defs attached.
+##   ambit::pyambit - the Python pybind11 library.
+#
+#
+# Suggested usage::
+#
+#   find_package(Einsums)
+##   find_package(ambit 0.6 CONFIG REQUIRED COMPONENTS shared)
+##
+##
+## The following variables can be set to guide the search for this package::
+##
+##   ambit_DIR - CMake variable, set to directory containing this Config file
+##   CMAKE_PREFIX_PATH - CMake variable, set to root directory of this package
+##   PATH - environment variable, set to bin directory of this package
+##   CMAKE_DISABLE_FIND_PACKAGE_ambit - CMake variable, disables
+##       find_package(ambit) perhaps to force internal build
+
+@PACKAGE_INIT@
+
+set(ein Einsums)  # NameSpace
+
+## check library style component
+## * using EXISTS Targets-shared instead of SHARED_ONLY so packages can
+##   truncate their builds (e.g., build static for tests but only ship shared)
+#if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${amb}Targets-shared.cmake")
+#    set(${amb}_shared_FOUND 1)
+#endif()
+#if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${amb}Targets-static.cmake")
+#    set(${amb}_static_FOUND 1)
+#endif()
+#list(FIND ${amb}_FIND_COMPONENTS "shared" _seek_shared)
+#list(FIND ${amb}_FIND_COMPONENTS "static" _seek_static)
+#
+## check Python interface component
+#if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${amb}Targets-Python.cmake")
+#    set(${amb}_Python_FOUND 1)
+#endif()
+#list(FIND ${amb}_FIND_COMPONENTS "Python" _seek_Python)
+#
+## make detectable the FindTarget*.cmake modules
+#list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+# check library dependency available
+include(CMakeFindDependencyMacro)
+if(@CBLAS_FOUND@)  # CBLAS_FOUND
+    find_dependency(CBLAS REQUIRED)
+else()
+    if(NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "CBLAS satisfied by source compiled into ${ein} distribution")
+    endif()
+endif()
+if(@LAPACKE_FOUND@)  # LAPACKE_FOUND
+    find_dependency(LAPACKE REQUIRED)
+else()
+    if(NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "LAPACKE satisfied by source compiled into ${ein} distribution")
+    endif()
+endif()
+#if(NOT TARGET tgt::hdf5)
+#    find_dependency(TargetHDF5 @TargetHDF5_VERSION_Mm@)
+#endif()
+#if(NOT TARGET tgt::lapack)
+#    find_dependency(TargetLAPACK)
+#endif()
+
+# Check all required components are available before trying to load any
+check_required_components(${ein})
+
+#-----------------------------------------------------------------------------
+# Don't include targets if this file is being picked up by another
+# project which has already built this as a subproject
+#-----------------------------------------------------------------------------
+if(NOT TARGET ${ein}::einsums)
+#    if(_seek_static GREATER -1)
+#        include("${CMAKE_CURRENT_LIST_DIR}/${amb}Targets-static.cmake")
+#    elseif(_seek_shared GREATER -1)
+#        include("${CMAKE_CURRENT_LIST_DIR}/${amb}Targets-shared.cmake")
+#    elseif(NOT @STATIC_ONLY@)  # STATIC_ONLY
+#        include("${CMAKE_CURRENT_LIST_DIR}/${amb}Targets-shared.cmake")
+#    elseif(NOT @SHARED_ONLY@)  # SHARED_ONLY
+#        include("${CMAKE_CURRENT_LIST_DIR}/${amb}Targets-static.cmake")
+#    endif()
+#
+#    get_property(_loc TARGET ${amb}::ambit PROPERTY LOCATION)
+#    get_property(_ill TARGET ${amb}::ambit PROPERTY INTERFACE_LINK_LIBRARIES)
+#    get_property(_iid TARGET ${amb}::ambit PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+#    get_property(_icd TARGET ${amb}::ambit PROPERTY INTERFACE_COMPILE_DEFINITIONS)
+#    set(${amb}_LIBRARY ${_loc})
+#    set(${amb}_LIBRARIES ${_loc};${_ill})
+#    set(${amb}_INCLUDE_DIR ${_iid})
+#    set(${amb}_INCLUDE_DIRS ${_iid})
+#    set(${amb}_DEFINITIONS ${_icd})
+#
+#    if(${amb}_Python_FOUND)
+#        include("${CMAKE_CURRENT_LIST_DIR}/${amb}Targets-Python.cmake")
+#        get_property(${amb}_PYMOD TARGET ${amb}::pyambit PROPERTY ambit_PYMOD)
+#    endif()
+
+    if (CMAKE_VERSION VERSION_GREATER 3.15)
+#        message(VERBOSE "ambit::ambit")
+#
+#        get_property(_ver TARGET ${amb}::ambit PROPERTY ambit_VERSION)
+#        message(VERBOSE "${amb}::ambit.${amb}_VERSION   ${_ver}")
+#
+#        message(VERBOSE "${amb}_FOUND                  ${${amb}_FOUND}")
+#        message(VERBOSE "${amb}_VERSION                ${${amb}_VERSION}")
+#        message(VERBOSE "${amb}_DEFINITIONS            ${${amb}_DEFINITIONS}")
+#
+#        message(VERBOSE "${amb}_LIBRARY                ${${amb}_LIBRARY}")
+#        message(VERBOSE "${amb}_LIBRARIES              ${${amb}_LIBRARIES}")
+#        message(VERBOSE "${amb}_INCLUDE_DIR            ${${amb}_INCLUDE_DIR}")
+#        message(VERBOSE "${amb}_INCLUDE_DIRS           ${${amb}_INCLUDE_DIRS}")
+#
+#        if (TARGET ${amb}::pyambit)
+#            message(VERBOSE "ambit::pyambit")
+#
+#            get_property(_ver TARGET ${amb}::pyambit PROPERTY ambit_VERSION)
+#            get_property(_pym TARGET ${amb}::pyambit PROPERTY ambit_PYMOD)
+#            message(VERBOSE "${amb}::pyambit.${amb}_VERSION ${_ver}")
+#            message(VERBOSE "${amb}::pyambit.${amb}_PYMOD   ${_pym}")
+#
+#            message(VERBOSE "${amb}_VERSION                ${${amb}_VERSION}")
+#            message(VERBOSE "${amb}_PYMOD                  ${${amb}_PYMOD}")
+#        endif()
+    endif()
+
+endif()

--- a/devtools/conda-envs/linux-dev.yml
+++ b/devtools/conda-envs/linux-dev.yml
@@ -7,7 +7,7 @@ dependencies:
 
   # OpenBLAS
   - libblas=*=*openblas
-  - openblas=*=*openmp*
+  - openblas=*=openmp*
 
   # Prebuilts to save einsums the work
   - catch2

--- a/devtools/conda-envs/macos-dev.yml
+++ b/devtools/conda-envs/macos-dev.yml
@@ -7,7 +7,7 @@ dependencies:
 
   # OpenBLAS
   - libblas=*=*openblas
-  - openblas=*=*openmp*
+  - openblas=*=openmp*
 
   # Prebuilts to save einsums the work
   - catch2

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -55,8 +55,7 @@ add_subdirectory(h5cpp-1.10.4-6-EAT)
 
 # <<< hptt >> Not using hptt is just asking for slow sorts.
 if(EINSUMS_USE_HPTT)
-  string(TOLOWER CMAKE_SYSTEM_PROCESSOR cm_sys_processor)
-  if(cm_sys_processor STREQUAL "arm64")
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "(arm64|ARM64)")
     set(ENABLE_ARM ON)
     set(ENABLE_AVX OFF)
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,9 +14,9 @@ add_einsums_library(einsums
     PUBLIC_INCLUDES
         include
     DEPENDS
-        Backward::Backward
         LAPACK::LAPACK
         BLAS::BLAS
+        Backward::Backward
     PUBLIC_DEPENDS
         range-v3::range-v3
         fmt::fmt

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,13 +14,13 @@ add_einsums_library(einsums
     PUBLIC_INCLUDES
         include
     DEPENDS
-        LAPACK::LAPACK
-        BLAS::BLAS
         Backward::Backward
     PUBLIC_DEPENDS
         range-v3::range-v3
         fmt::fmt
         h5cpp::h5cpp
+        LAPACK::LAPACK
+        BLAS::BLAS
 )
 
 # extend_einsums_target(einsums

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,12 +15,12 @@ add_einsums_library(einsums
         include
     DEPENDS
         Backward::Backward
+        LAPACK::LAPACK
+        BLAS::BLAS
     PUBLIC_DEPENDS
         range-v3::range-v3
         fmt::fmt
         h5cpp::h5cpp
-        LAPACK::LAPACK
-        BLAS::BLAS
 )
 
 # extend_einsums_target(einsums


### PR DESCRIPTION
- [x] it gets awkward to form environments from spec files when you want to vary the build conditions a lot, so I switched to a export.yaml file constructed in the GHA. now testing MKL on release linux (2 lanes) and sticking with openblas for the rest (6 lanes).
- [x] standardized on `Einsums` for cmake stuff: `project(Einsums`, `cmake/EinsumsAPI.cmake:    add_library(Einsums::${name}`, and added starter EinsumsConfig.cmake.in
- [x] made testing optional
- [x] MKL+Linux+HTTP=OFF was getting a warning on `WARNING: CP decomposition failed to converge in 50 iterations` when running `./test-all`. avoiding that in GHA by running ctest